### PR TITLE
Integrate all mt models in eval api

### DIFF
--- a/src/eval_api/README.md
+++ b/src/eval_api/README.md
@@ -42,6 +42,8 @@ If you want to use a different config path, set:
 export MODELS_CONFIG_PATH=./models.json
 ```
 
+When adding a model that has specific configuration requirements, other than what is supplied by the `transformers` adapter, you might need to create a subclass of the `TransformersAdapter` class in `transformers.py` and add it in the functions `_build_adapter` and `_resolve_model_ref` in `registry.py`.
+
 ## Run
 
 ```bash

--- a/src/eval_api/app/adapters/transformers.py
+++ b/src/eval_api/app/adapters/transformers.py
@@ -126,6 +126,9 @@ class NLLBAdapter(TransformersAdapter):
             prior_src_lang = getattr(self.tokenizer, "src_lang")
             self.tokenizer.src_lang = src_lang
 
+        if hasattr(self.tokenizer, "tgt_lang"):
+            prior_tgt_lang = getattr(self.tokenizer, "tgt_lang")
+
         if hasattr(self.tokenizer, "set_tgt_lang_special_tokens"):
             self.tokenizer.set_tgt_lang_special_tokens(tgt_lang)
 
@@ -137,3 +140,32 @@ class NLLBAdapter(TransformersAdapter):
                 logger.debug(f"Found forced_bos_token_id={forced_bos_token_id} from cur_lang_code")
 
         return forced_bos_token_id, prior_src_lang, prior_tgt_lang
+    
+class OpusMTAdapter(TransformersAdapter):
+    def translate(self, src_lang: str, tgt_lang: str, text: str) -> str:
+        """OPUS-MT models require language tags prepended to source text."""
+        tagged_text = f">>{tgt_lang}<< {text}"
+        
+        forced_bos_token_id, prior_src_lang, prior_tgt_lang = self._prepare_language(
+            src_lang,
+            tgt_lang,
+        )
+        try:
+            inputs = self.tokenizer(tagged_text, return_tensors="pt")
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        finally:
+            self._restore_language(prior_src_lang, prior_tgt_lang)
+
+        generate_kwargs = {
+            "num_beams": self.num_beams,
+            "max_new_tokens": self.max_new_tokens,
+            "do_sample": False,
+        }
+        if forced_bos_token_id is not None:
+            generate_kwargs["forced_bos_token_id"] = forced_bos_token_id
+
+        with torch.no_grad():
+            output_tokens = self.model.generate(**inputs, **generate_kwargs)
+
+        translated = self.tokenizer.decode(output_tokens[0], skip_special_tokens=True)
+        return translated

--- a/src/eval_api/app/adapters/transformers.py
+++ b/src/eval_api/app/adapters/transformers.py
@@ -111,3 +111,29 @@ class TransformersAdapter(ModelAdapter):
             logger.warning("CUDA requested but not available. Falling back to CPU.")
             return torch.device("cpu")
         return torch.device(device)
+    
+class NLLBAdapter(TransformersAdapter):    
+    def _prepare_language(
+        self,
+        src_lang: str,
+        tgt_lang: str,
+    ) -> tuple[Optional[int], object, object]:
+        """Override to handle NLLB set_tgt_lang_special_tokens correctly."""
+        prior_src_lang = _UNSET
+        prior_tgt_lang = _UNSET
+
+        if hasattr(self.tokenizer, "src_lang"):
+            prior_src_lang = getattr(self.tokenizer, "src_lang")
+            self.tokenizer.src_lang = src_lang
+
+        if hasattr(self.tokenizer, "set_tgt_lang_special_tokens"):
+            self.tokenizer.set_tgt_lang_special_tokens(tgt_lang)
+
+        forced_bos_token_id = self.forced_bos_token_id
+        if forced_bos_token_id is None:
+            cur_lang_code = getattr(self.tokenizer, "cur_lang_code", None)
+            if isinstance(cur_lang_code, int):
+                forced_bos_token_id = cur_lang_code
+                logger.debug(f"Found forced_bos_token_id={forced_bos_token_id} from cur_lang_code")
+
+        return forced_bos_token_id, prior_src_lang, prior_tgt_lang

--- a/src/eval_api/app/registry.py
+++ b/src/eval_api/app/registry.py
@@ -39,7 +39,6 @@ class ModelRegistry:
             raise ValueError("models.json must contain an object at the top level")
 
         configs: Dict[str, ModelConfig] = {}
-        adapters: Dict[str, ModelAdapter] = {}
 
         for model_id, raw_config in data.items():
             if not isinstance(raw_config, dict):
@@ -58,7 +57,7 @@ class ModelRegistry:
             supported_pairs = self._parse_supported_pairs(raw_config.get("supported_pairs"))
             model_ref = self._resolve_model_ref(adapter_name, model_path_raw, adapter_params)
 
-            config = ModelConfig(
+            configs[model_id] = ModelConfig(
                 model_id=model_id,
                 adapter=adapter_name,
                 model_path=model_ref,
@@ -66,18 +65,18 @@ class ModelRegistry:
                 adapter_params=adapter_params,
             )
 
-            adapter = self._build_adapter(config)
-            configs[model_id] = config
-            adapters[model_id] = adapter
-
         self._configs = configs
-        self._adapters = adapters
+        self._adapters = {}   # clear any old cache
 
     def get_adapter(self, model_id: str) -> ModelAdapter:
-        try:
+        if model_id in self._adapters:
             return self._adapters[model_id]
-        except KeyError as exc:
-            raise KeyError(f"Unknown model_id: {model_id}") from exc
+
+        config = self.get_config(model_id)
+        adapter = self._build_adapter(config)
+        self._adapters[model_id] = adapter
+        return adapter
+
 
     def get_config(self, model_id: str) -> ModelConfig:
         try:

--- a/src/eval_api/app/registry.py
+++ b/src/eval_api/app/registry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Set, Tuple
 
 from .adapters.base import ModelAdapter
-from .adapters.transformers import TransformersAdapter
+from .adapters.transformers import TransformersAdapter, NLLBAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +97,8 @@ class ModelRegistry:
     def _build_adapter(self, config: ModelConfig) -> ModelAdapter:
         if config.adapter == "transformers":
             return TransformersAdapter(config.model_path, **config.adapter_params)
+        elif config.adapter == "nllb":
+            return NLLBAdapter(config.model_path, **config.adapter_params)
         raise ValueError(f"Unsupported adapter: {config.adapter}")
 
     @staticmethod
@@ -131,7 +133,7 @@ class ModelRegistry:
             raise ValueError("model_path must be a string")
 
         local_files_only = bool(adapter_params.get("local_files_only", True))
-        if adapter_name == "transformers":
+        if adapter_name in ("transformers", "nllb"):
             candidate = Path(model_path_raw)
             if not candidate.is_absolute():
                 candidate = (BASE_DIR / candidate).resolve()

--- a/src/eval_api/app/registry.py
+++ b/src/eval_api/app/registry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Set, Tuple
 
 from .adapters.base import ModelAdapter
-from .adapters.transformers import TransformersAdapter, NLLBAdapter
+from .adapters.transformers import TransformersAdapter, NLLBAdapter, OpusMTAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,8 @@ class ModelRegistry:
             return TransformersAdapter(config.model_path, **config.adapter_params)
         elif config.adapter == "nllb":
             return NLLBAdapter(config.model_path, **config.adapter_params)
+        elif config.adapter == "opusmt":
+            return OpusMTAdapter(config.model_path, **config.adapter_params)
         raise ValueError(f"Unsupported adapter: {config.adapter}")
 
     @staticmethod
@@ -132,7 +134,7 @@ class ModelRegistry:
             raise ValueError("model_path must be a string")
 
         local_files_only = bool(adapter_params.get("local_files_only", True))
-        if adapter_name in ("transformers", "nllb"):
+        if adapter_name in ("transformers", "nllb", "opusmt"):
             candidate = Path(model_path_raw)
             if not candidate.is_absolute():
                 candidate = (BASE_DIR / candidate).resolve()

--- a/src/eval_api/models.json
+++ b/src/eval_api/models.json
@@ -1,6 +1,6 @@
   {
     "opus-mt-en-gmq": {
-      "adapter": "transformers",
+      "adapter": "opusmt",
       "model_path": "Helsinki-NLP/opus-mt-en-gmq",
       "supported_pairs": [
         ["en", "nob"],
@@ -10,7 +10,7 @@
       "local_files_only": false
     },
       "opus-mt-en-de": {
-      "adapter": "transformers",
+      "adapter": "opusmt",
       "model_path": "Helsinki-NLP/opus-mt-en-de",
       "supported_pairs": [
         ["en", "de"]
@@ -19,7 +19,7 @@
       "local_files_only": false
     },
     "opus-mt-tc-big-en-pt": {
-      "adapter": "transformers",
+      "adapter": "opusmt",
       "model_path": "Helsinki-NLP/opus-mt-tc-big-en-pt",
       "supported_pairs": [
         ["en", "pt"]

--- a/src/eval_api/models.json
+++ b/src/eval_api/models.json
@@ -3,14 +3,48 @@
       "adapter": "transformers",
       "model_path": "Helsinki-NLP/opus-mt-en-gmq",
       "supported_pairs": [
-        [
-          "en",
-          "nob"
-        ],
-        [
-          "en",
-          "nno"
-        ]
+        ["en", "nob"],
+        ["en", "nno"]
+      ],
+      "device": "cpu",
+      "local_files_only": false
+    },
+      "opus-mt-en-de": {
+      "adapter": "transformers",
+      "model_path": "Helsinki-NLP/opus-mt-en-de",
+      "supported_pairs": [
+        ["en", "de"]
+      ],
+      "device": "cpu",
+      "local_files_only": false
+    },
+    "opus-mt-tc-big-en-pt": {
+      "adapter": "transformers",
+      "model_path": "Helsinki-NLP/opus-mt-tc-big-en-pt",
+      "supported_pairs": [
+        ["en", "pt"]
+      ],
+      "device": "cpu",
+      "local_files_only": false
+    },
+    "m2m-100-418m": {
+      "adapter": "transformers",
+      "model_path": "facebook/m2m100_418M",
+      "supported_pairs": [
+        ["en", "de"],
+        ["en", "no"],
+        ["en", "pt"]
+      ],
+      "device": "cpu",
+      "local_files_only": false
+    },
+    "nllb-200-distilled-600m": {
+      "adapter": "nllb",
+      "model_path": "facebook/nllb-200-distilled-600M",
+      "supported_pairs": [
+        ["eng_Latn", "deu_Latn"],
+        ["eng_Latn", "nob_Latn"],
+        ["eng_Latn", "por_Latn"]
       ],
       "device": "cpu",
       "local_files_only": false


### PR DESCRIPTION
Changes:
- Added all must-have models to models.json
- Implemented necessary adapter subclasses for new models
- Fixed ModelRegistry to only load single model per subprocess, avoiding memory pollution